### PR TITLE
[StableDiffusion Sample][NvTensorRTRTX EP] Add free dimension overrides for SD1.4 components

### DIFF
--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/SafetyChecker.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/SafetyChecker.cs
@@ -96,14 +96,7 @@ internal class SafetyChecker : IDisposable
         var inputTensor = ClipImageFeatureExtractor(resultImage, config);
 
         // images input
-        if(device == "NvTensorRTRTXExecutionProvider")
-        {
-            var inputImagesTensor = inputTensor;
-        }
-        else
-        {
-            var inputImagesTensor = ReorderTensor(inputTensor);
-        }
+        var inputImagesTensor = ReorderTensor(inputTensor);
 
         var input = new List<NamedOnnxValue>
         {

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/SafetyChecker.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/SafetyChecker.cs
@@ -58,6 +58,14 @@ internal class SafetyChecker : IDisposable
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
 
+            if(device == "NvTensorRTRTXExecutionProvider")
+            {
+                sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
+                sessionOptions.AddFreeDimensionOverrideByName("channels", 3);
+                sessionOptions.AddFreeDimensionOverrideByName("height", 224);
+                sessionOptions.AddFreeDimensionOverrideByName("width", 224);
+            }
+
             if (policy != null)
             {
                 sessionOptions.SetEpSelectionPolicy(policy.Value);
@@ -88,7 +96,14 @@ internal class SafetyChecker : IDisposable
         var inputTensor = ClipImageFeatureExtractor(resultImage, config);
 
         // images input
-        var inputImagesTensor = ReorderTensor(inputTensor);
+        if(device == "NvTensorRTRTXExecutionProvider")
+        {
+            var inputImagesTensor = inputTensor;
+        }
+        else
+        {
+            var inputImagesTensor = ReorderTensor(inputTensor);
+        }
 
         var input = new List<NamedOnnxValue>
         {

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/SafetyChecker.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/SafetyChecker.cs
@@ -58,13 +58,10 @@ internal class SafetyChecker : IDisposable
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
 
-            if(device == "NvTensorRTRTXExecutionProvider")
-            {
-                sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
-                sessionOptions.AddFreeDimensionOverrideByName("channels", 3);
-                sessionOptions.AddFreeDimensionOverrideByName("height", 224);
-                sessionOptions.AddFreeDimensionOverrideByName("width", 224);
-            }
+            sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
+            sessionOptions.AddFreeDimensionOverrideByName("channels", 3);
+            sessionOptions.AddFreeDimensionOverrideByName("height", 224);
+            sessionOptions.AddFreeDimensionOverrideByName("width", 224);
 
             if (policy != null)
             {

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
@@ -83,15 +83,12 @@ internal class StableDiffusion : IDisposable
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
 
-            if(device == "NvTensorRTRTXExecutionProvider")
-            {
-                sessionOptions.AddFreeDimensionOverrideByName("batch", 2);
-                sessionOptions.AddFreeDimensionOverrideByName("time_batch", 1);
-                sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
-                sessionOptions.AddFreeDimensionOverrideByName("height", 64);
-                sessionOptions.AddFreeDimensionOverrideByName("width", 64);
-                sessionOptions.AddFreeDimensionOverrideByName("sequence", 77);
-            }
+            sessionOptions.AddFreeDimensionOverrideByName("batch", 2);
+            sessionOptions.AddFreeDimensionOverrideByName("time_batch", 1);
+            sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
+            sessionOptions.AddFreeDimensionOverrideByName("height", 64);
+            sessionOptions.AddFreeDimensionOverrideByName("width", 64);
+            sessionOptions.AddFreeDimensionOverrideByName("sequence", 77);
             
 
             if (policy != null)

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
@@ -83,6 +83,17 @@ internal class StableDiffusion : IDisposable
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
 
+            if(device == "NvTensorRTRTXExecutionProvider")
+            {
+                sessionOptions.AddFreeDimensionOverrideByName("batch", 2);
+                sessionOptions.AddFreeDimensionOverrideByName("time_batch", 1);
+                sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
+                sessionOptions.AddFreeDimensionOverrideByName("height", 64);
+                sessionOptions.AddFreeDimensionOverrideByName("width", 64);
+                sessionOptions.AddFreeDimensionOverrideByName("sequence", 77);
+            }
+            
+
             if (policy != null)
             {
                 sessionOptions.SetEpSelectionPolicy(policy.Value);

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/TextProcessing.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/TextProcessing.cs
@@ -59,14 +59,11 @@ internal class TextProcessing : IDisposable
 
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
-
-            if(device == "NvTensorRTRTXExecutionProvider")
-            {
-                sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
-                sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
-                sessionOptions.AddFreeDimensionOverrideByName("height", 512);
-                sessionOptions.AddFreeDimensionOverrideByName("width", 512);
-            }
+            
+            sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
+            sessionOptions.AddFreeDimensionOverrideByName("channels", 3);
+            sessionOptions.AddFreeDimensionOverrideByName("height", 512);
+            sessionOptions.AddFreeDimensionOverrideByName("width", 512);            
 
             if (policy != null)
             {

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/TextProcessing.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/TextProcessing.cs
@@ -60,6 +60,14 @@ internal class TextProcessing : IDisposable
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
 
+            if(device == "NvTensorRTRTXExecutionProvider")
+            {
+                sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
+                sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
+                sessionOptions.AddFreeDimensionOverrideByName("height", 512);
+                sessionOptions.AddFreeDimensionOverrideByName("width", 512);
+            }
+
             if (policy != null)
             {
                 sessionOptions.SetEpSelectionPolicy(policy.Value);

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
@@ -57,6 +57,14 @@ internal class VaeDecoder : IDisposable
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
 
+            if(device == "NvTensorRTRTXExecutionProvider")
+            {
+                sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
+                sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
+                sessionOptions.AddFreeDimensionOverrideByName("height", 64);
+                sessionOptions.AddFreeDimensionOverrideByName("width", 64);
+            }            
+
             if (policy != null)
             {
                 sessionOptions.SetEpSelectionPolicy(policy.Value);

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
@@ -57,13 +57,10 @@ internal class VaeDecoder : IDisposable
             SessionOptions sessionOptions = new();
             sessionOptions.RegisterOrtExtensions();
 
-            if(device == "NvTensorRTRTXExecutionProvider")
-            {
-                sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
-                sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
-                sessionOptions.AddFreeDimensionOverrideByName("height", 64);
-                sessionOptions.AddFreeDimensionOverrideByName("width", 64);
-            }            
+            sessionOptions.AddFreeDimensionOverrideByName("batch", 1);
+            sessionOptions.AddFreeDimensionOverrideByName("channels", 4);
+            sessionOptions.AddFreeDimensionOverrideByName("height", 64);
+            sessionOptions.AddFreeDimensionOverrideByName("width", 64);
 
             if (policy != null)
             {


### PR DESCRIPTION
Initialization of Stable Diffusion pipeline in sample application was failing when run through NVTensorRTRTX Execution Provider. The initialization requires dynamic dimensions in model inputs to be set explicitly through free dimension overrides. Some components require editing the model input to accomodate the overrides. 

This PR:
1. sets free dimension overrides corresponding to the dimension values used in sample
2. requires unet model input labelled **"timestep"** to have dimension name **"time_batch"** instead of **"batch"**
3. requires safetychecker model input labelled **"images"** to have shape **{batch,height,weight,channels}** instead of **{batch,channels,height,weight}** as this input is reordered before model is used.